### PR TITLE
Use UObject instead of UCameraMode to support versions below 5.4

### DIFF
--- a/Source/ModalCamera/Private/ModalCameraComponent.cpp
+++ b/Source/ModalCamera/Private/ModalCameraComponent.cpp
@@ -1,12 +1,12 @@
 // Copyright Chronicler.
 
-#include "../Public/ModalCameraComponent.h"
+#include "ModalCameraComponent.h"
 
 #include "Engine/Canvas.h"
 #include "Engine/Engine.h"
 #include "GameFramework/Pawn.h"
 #include "GameFramework/PlayerController.h"
-#include "..\Public\ModalCameraMode.h"
+#include "ModalCameraMode.h"
 #include "ModularGameplayTags.h"
 #include "ModularPlayerState.h"
 #include "ActorComponent/ModularPawnComponent.h"
@@ -265,7 +265,7 @@ void UModalCameraComponent::CheckDefaultInitialization()
 	ContinueInitStateChain(StateChain);
 }
 
-TSubclassOf<UCameraMode> UModalCameraComponent::DetermineCameraMode() const
+TSubclassOf<UModalCameraMode> UModalCameraComponent::DetermineCameraMode() const
 {
 	if (AbilityCameraMode)
 	{

--- a/Source/ModalCamera/Private/ModalCameraMode.cpp
+++ b/Source/ModalCamera/Private/ModalCameraMode.cpp
@@ -1,8 +1,11 @@
 // Copyright Chronicler.
 
-#include "..\Public\ModalCameraMode.h"
+#include "ModalCameraMode.h"
 
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4
 #include "InterchangeAnimationDefinitions.h"
+#endif
+
 #include "ModalCameraComponent.h"
 #include "Components/CapsuleComponent.h"
 #include "Engine/Canvas.h"

--- a/Source/ModalCamera/Public/ModalCameraComponent.h
+++ b/Source/ModalCamera/Public/ModalCameraComponent.h
@@ -13,7 +13,7 @@
 
 template <class TClass> class TSubclassOf;
 
-DECLARE_DELEGATE_RetVal(TSubclassOf<UCameraMode>, FCameraModeDelegate);
+DECLARE_DELEGATE_RetVal(TSubclassOf<UModalCameraMode>, FCameraModeDelegate);
 
 
 /**
@@ -33,7 +33,7 @@ public:
 
 	// Default camera mode used by player controlled pawns.
 	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Camera")
-	TSubclassOf<UCameraMode> DefaultCameraMode;
+	TSubclassOf<UModalCameraMode> DefaultCameraMode;
 
 	// Returns the camera component if one exists on the specified actor.
 	UFUNCTION(BlueprintPure, Category = "Camera")
@@ -123,7 +123,7 @@ protected:
 	UPROPERTY()
 	TObjectPtr<UCameraModeStack> CameraModeStack;
 
-	TSubclassOf<UCameraMode> DetermineCameraMode() const;
+	TSubclassOf<UModalCameraMode> DetermineCameraMode() const;
 
 	// Offset applied to the field of view.  The offset is only for one frame, it gets cleared once it is applied.
 	float FieldOfViewOffset;
@@ -137,7 +137,7 @@ protected:
 protected:
 	/** Camera mode set by an ability. */
 	UPROPERTY()
-	TSubclassOf<UCameraMode> AbilityCameraMode;
+	TSubclassOf<UModalCameraMode> AbilityCameraMode;
 
 	/** Spec handle for the last ability to set a camera mode. */
 	FGameplayAbilitySpecHandle AbilityCameraModeOwningSpecHandle;

--- a/Source/ModalCamera/Public/ModalCameraMode.h
+++ b/Source/ModalCamera/Public/ModalCameraMode.h
@@ -4,7 +4,6 @@
 
 #include "Engine/World.h"
 #include "GameplayTagContainer.h"
-#include "ModalCamera/Public/CameraModes/CameraMode.h"
 
 #include "ModalCameraMode.generated.h"
 
@@ -65,7 +64,7 @@ public:
  *	Base class for all camera modes.
  */
 UCLASS(Abstract, NotBlueprintable)
-class MODALCAMERA_API UModalCameraMode : public UCameraMode
+class MODALCAMERA_API UModalCameraMode : public UObject
 {
 	GENERATED_BODY()
 


### PR DESCRIPTION
I don't know why UCameraMode is used, but it will make lower versions unsupported. I hope it can be compatible with the previous versions.